### PR TITLE
Hooks query options fixes

### DIFF
--- a/src/hooks/use-search-query.ts
+++ b/src/hooks/use-search-query.ts
@@ -1,5 +1,5 @@
 import { RefetchConfigOptions, SubscriptionOptions } from '@reduxjs/toolkit/dist/query/core/apiState.d';
-import { useEffect, useState } from 'react';
+import { SetStateAction, useCallback, useEffect, useState } from 'react';
 import { BaseEntity, PaginationRequest, PaginationResponse } from '../models';
 import { EntityApi, EntityMutationEndpointName } from '../types';
 
@@ -14,12 +14,21 @@ export const useSearchQuery = <
 ): typeof result => {
   const [isRefetching, setIsRefetching] = useState(false);
   const [searchRequest, setSearchRequest] = useState<TRequest>(initialParams as TRequest);
-  const { refetch, isFetching, ...restEndpointData } = entityApi.useSearchQuery(searchRequest, queryOptions);
+  const [searchOptions, setSearchOptions] = useState(queryOptions);
+  const { refetch, isFetching, ...restEndpointData } = entityApi.useSearchQuery(searchRequest, searchOptions);
 
   const handleRefetch = (): void => {
     setIsRefetching(true);
     refetch();
   };
+
+  const changeSearchRequest = useCallback(
+    (setSearchRequestAction: SetStateAction<TRequest>) => {
+      setSearchRequest(setSearchRequestAction);
+      setSearchOptions(queryOptions);
+    },
+    [queryOptions],
+  );
 
   useEffect(() => {
     if (!isFetching) {
@@ -33,7 +42,7 @@ export const useSearchQuery = <
     isRefetching,
     refetch: handleRefetch,
     searchRequest,
-    setSearchRequest
+    setSearchRequest: changeSearchRequest
   };
 
   return result;


### PR DESCRIPTION
Fixes inconstancy in `searchRequest` and `queryOptions` if `searchRequest` changes outside in `useEffect` and both `searchRequest` and `queryOptions`  depends on same data.

Current behaviour - `queryOptions` passes in `useSearchInfiniteQuery` as is and changes in same render as data on which it depends. But `searchRequest` may be changed in `useEffect` wich depends on data and it will happens in next render after data changes.
As result we may have unnecessary api call with not fulfilled by necessary data `searchRequest`. Sometimes it produces renders with not expected data from response, or, possible, errors because not enough search params in request.

Fixed behaviour - we have state inside hook wich stores actual `queryOptions` - `searchOptions` and sync them with `queryOptions`  from outside automatically with changing of `searchRequest` without dependency of how and where we do it.