### PR TITLE
Temporary fix for updating entity cache of infinite queries

### DIFF
--- a/src/utils/create-entity-api-utils.ts
+++ b/src/utils/create-entity-api-utils.ts
@@ -1,6 +1,7 @@
 import { PatchCollection } from '@reduxjs/toolkit/dist/query/core/buildThunks.d';
 import { ClassConstructor } from 'class-transformer';
 import { merge } from 'lodash';
+import { EntityTagID } from '../enums';
 import { BaseEntity, EntityRequest, PaginationRequest, PaginationResponse } from '../models';
 import {
   EntityApi,
@@ -50,7 +51,10 @@ export const createEntityApiUtils = <
         return patchResults;
       }
 
-      const cachedQueries = api.util.selectInvalidatedBy(getState(), [{ type: entityName, id: entityData.id }]);
+      const cachedQueries = api.util.selectInvalidatedBy(getState(), [
+        { type: entityName, id: entityData.id },
+        { type: entityName, id: EntityTagID.LIST }
+      ]);
 
       for (const { endpointName, originalArgs } of cachedQueries) {
         const existingEntity = shouldRefetchEntity
@@ -86,7 +90,10 @@ export const createEntityApiUtils = <
         return patchResults;
       }
 
-      const cachedQueries = api.util.selectInvalidatedBy(getState(), [{ type: entityName, id }]);
+      const cachedQueries = api.util.selectInvalidatedBy(getState(), [
+        { type: entityName, id },
+        { type: entityName, id: EntityTagID.LIST }
+      ]);
 
       for (const { endpointName, originalArgs } of cachedQueries) {
         const action = api.util.updateQueryData(

--- a/src/utils/create-entity-api-utils.ts
+++ b/src/utils/create-entity-api-utils.ts
@@ -53,6 +53,7 @@ export const createEntityApiUtils = <
 
       const cachedQueries = api.util.selectInvalidatedBy(getState(), [
         { type: entityName, id: entityData.id },
+        // TODO: Remove selecting all lists once issue is fixed: https://github.com/reduxjs/redux-toolkit/issues/3583
         { type: entityName, id: EntityTagID.LIST }
       ]);
 
@@ -92,6 +93,7 @@ export const createEntityApiUtils = <
 
       const cachedQueries = api.util.selectInvalidatedBy(getState(), [
         { type: entityName, id },
+        // TODO: Remove selecting all lists once issue is fixed: https://github.com/reduxjs/redux-toolkit/issues/3583
         { type: entityName, id: EntityTagID.LIST }
       ]);
 


### PR DESCRIPTION
The default behaviour of `providesTags` has been [changed in RTKQ](https://github.com/reduxjs/redux-toolkit/issues/2661), and it caused [this issue for infinite queries](https://github.com/reduxjs/redux-toolkit/issues/3583). Added a workaround until `providesTags` will provide access all cached data for endpoint.

@ekazankova @Al1erEgo FYI