### PR TITLE
Reorganized custom hooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ronas-it/rtkq-entity-api",
-  "version": "0.2.8",
+  "version": "0.3.0-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ronas-it/rtkq-entity-api",
-      "version": "0.2.8",
+      "version": "0.3.0-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@reduxjs/toolkit": "^2.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@ronas-it/rtkq-entity-api",
-  "version": "0.3.0-alpha.1",
+  "version": "0.3.0-alpha.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@ronas-it/rtkq-entity-api",
-      "version": "0.3.0-alpha.1",
+      "version": "0.3.0-alpha.2",
       "license": "MIT",
       "dependencies": {
         "@reduxjs/toolkit": "^2.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ronas-it/rtkq-entity-api",
-  "version": "0.2.8",
+  "version": "0.3.0-alpha.1",
   "description": "Wrapper utilities for CRUD operations with REST APIs entities using RTK Query",
   "license": "MIT",
   "author": "Ronas IT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ronas-it/rtkq-entity-api",
-  "version": "0.3.0-alpha.1",
+  "version": "0.3.0-alpha.2",
   "description": "Wrapper utilities for CRUD operations with REST APIs entities using RTK Query",
   "license": "MIT",
   "author": "Ronas IT",

--- a/src/hooks/use-infinite-query.ts
+++ b/src/hooks/use-infinite-query.ts
@@ -16,7 +16,7 @@ export const useInfiniteQuery = <
 >(
   entityApi: Pick<
     EntityApi<TEntity, TRequest, any, TPaginationResponse, Array<EntityMutationEndpointName>>,
-    'useSearchInfiniteQuery' | 'endpoints' | 'util'
+    'endpoints' | 'util'
   >,
   initialParams?: TRequest,
   queryOptions?: Partial<SubscriptionOptions & RefetchConfigOptions & { skip?: boolean }>,
@@ -25,7 +25,9 @@ export const useInfiniteQuery = <
   const dispatch: ThunkDispatch<any, any, UnknownAction> = useDispatch();
   const [searchRequest, setSearchRequest] = useState<TRequest>(initialParams as TRequest);
   const [searchOptions, setSearchOptions] = useState(queryOptions);
-  const { data, isFetching, ...restEndpointData } = entityApi.useSearchInfiniteQuery(searchRequest, searchOptions);
+  const { data, isFetching, ...restEndpointData } = (
+    entityApi as EntityApi<TEntity, TRequest, any, TPaginationResponse>
+  ).useSearchInfiniteQuery(searchRequest, searchOptions);
   const [isRefetching, setIsRefetching] = useState<boolean>(false);
   const [isFetchingNextPage, setIsFetchingNextPage] = useState(false);
   const [isFetchingPreviousPage, setIsFetchingPreviousPage] = useState(false);

--- a/src/hooks/use-infinite-query.ts
+++ b/src/hooks/use-infinite-query.ts
@@ -6,6 +6,9 @@ import { useDispatch } from 'react-redux';
 import { BaseEntity, PaginationRequest, PaginationResponse } from '../models';
 import { EntityApi, EntityMutationEndpointName } from '../types';
 
+/**
+ * @deprecated This hook will be removed. Instead, use 'useSearchInfiniteQuery' hook in your entity API directly
+ */
 export const useInfiniteQuery = <
   TEntity extends BaseEntity,
   TRequest extends PaginationRequest,

--- a/src/hooks/use-search-query.ts
+++ b/src/hooks/use-search-query.ts
@@ -12,14 +12,19 @@ export const useSearchQuery = <
   TRequest extends PaginationRequest,
   TResponse extends PaginationResponse<TEntity>,
 >(
-  entityApi: EntityApi<TEntity, TRequest, any, TResponse, Array<EntityMutationEndpointName>>,
+  entityApi: Pick<
+    EntityApi<TEntity, TRequest, any, TResponse, Array<EntityMutationEndpointName>>,
+    'endpoints' | 'util'
+  >,
   initialParams?: TRequest,
   queryOptions?: SubscriptionOptions & RefetchConfigOptions & { skip?: boolean },
 ): typeof result => {
   const [isRefetching, setIsRefetching] = useState(false);
   const [searchRequest, setSearchRequest] = useState<TRequest>(initialParams as TRequest);
   const [searchOptions, setSearchOptions] = useState(queryOptions);
-  const { refetch, isFetching, ...restEndpointData } = entityApi.useSearchQuery(searchRequest, searchOptions);
+  const { refetch, isFetching, ...restEndpointData } = (
+    entityApi as EntityApi<TEntity, TRequest, any, TResponse>
+  ).useSearchQuery(searchRequest, searchOptions);
 
   const handleRefetch = (): void => {
     setIsRefetching(true);

--- a/src/hooks/use-search-query.ts
+++ b/src/hooks/use-search-query.ts
@@ -4,6 +4,9 @@ import { useEffect, useState } from 'react';
 import { BaseEntity, PaginationRequest, PaginationResponse } from '../models';
 import { EntityApi, EntityMutationEndpointName } from '../types';
 
+/**
+ * @deprecated This hook will be removed. Instead, use 'useSearchQuery' hook in your entity API directly
+ */
 export const useSearchQuery = <
   TEntity extends BaseEntity,
   TRequest extends PaginationRequest,

--- a/src/types/custom-hooks.ts
+++ b/src/types/custom-hooks.ts
@@ -1,0 +1,10 @@
+import { BaseEntity, PaginationRequest, PaginationResponse } from '../models';
+import { createInfiniteQueryHook } from '../utils';
+
+export type EntityApiCustomHooks<
+  TEntity extends BaseEntity = BaseEntity,
+  TSearchRequest extends PaginationRequest = PaginationRequest,
+  TSearchResponse extends PaginationResponse<TEntity> = PaginationResponse<TEntity>,
+> = {
+  useSearchInfiniteQuery: ReturnType<typeof createInfiniteQueryHook<TEntity, TSearchRequest, TSearchResponse>>;
+};

--- a/src/types/entity-api.ts
+++ b/src/types/entity-api.ts
@@ -9,6 +9,7 @@ import { NoInfer } from '@reduxjs/toolkit/dist/tsHelpers.d';
 import { Api, MutationDefinition, QueryDefinition } from '@reduxjs/toolkit/query/react';
 import { BaseEntity, EntityRequest, PaginationRequest, PaginationResponse } from '../models';
 import { BaseQueryFunction } from '../utils';
+import { EntityApiCustomHooks } from './custom-hooks';
 import { EntityApiUtils } from './entity-api-utils';
 import { EntityPartial } from './entity-partial';
 
@@ -45,14 +46,18 @@ export type EntityApi<
   injectEndpoints<TNewDefinitions extends EndpointDefinitions>(_: {
     endpoints: (build: EndpointBuilder<BaseQueryFunction, string, string>) => TNewDefinitions;
     overrideExisting?: boolean;
-  }): EntityApi<
-    TEntity,
-    TSearchRequest,
-    TEntityRequest,
-    TSearchResponse,
-    TOmitEndpoints,
-    TEndpointDefinitions & TNewDefinitions
-  >;
+  }): Omit<
+    EntityApi<
+      TEntity,
+      TSearchRequest,
+      TEntityRequest,
+      TSearchResponse,
+      TOmitEndpoints,
+      TEndpointDefinitions & TNewDefinitions
+    >,
+    keyof EntityApiCustomHooks
+  > &
+    EntityApiCustomHooks<TEntity, TSearchRequest, TSearchResponse>;
 
   enhanceEndpoints<TNewTagTypes extends string = never, TNewDefinitions extends EndpointDefinitions = never>(_: {
     addTagTypes?: Array<TNewTagTypes>;
@@ -65,14 +70,18 @@ export type EntityApi<
           [K in keyof NewDefinitions]?: Partial<NewDefinitions[K]> | ((definition: NewDefinitions[K]) => void);
         }
       : never;
-  }): EntityApi<
-    TEntity,
-    TSearchRequest,
-    TEntityRequest,
-    TSearchResponse,
-    TOmitEndpoints,
-    TEndpointDefinitions | TNewDefinitions
-  >;
+  }): Omit<
+    EntityApi<
+      TEntity,
+      TSearchRequest,
+      TEntityRequest,
+      TSearchResponse,
+      TOmitEndpoints,
+      TEndpointDefinitions | TNewDefinitions
+    >,
+    keyof EntityApiCustomHooks
+  > &
+    EntityApiCustomHooks<TEntity, TSearchRequest, TSearchResponse>;
 } & { util: EntityApiUtils<TEntity, TSearchRequest> };
 
 export type EntityEndpointName = keyof EntityEndpointsDefinitions<BaseEntity>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,6 +1,7 @@
 export * from './any-api';
 export * from './base-order-by';
 export * from './cached-query';
+export * from './custom-hooks';
 export * from './entity-api';
 export * from './entity-api-utils';
 export * from './entity-partial';

--- a/src/utils/create-entity-api-utils.ts
+++ b/src/utils/create-entity-api-utils.ts
@@ -125,7 +125,8 @@ export const createEntityApiUtils = <
         await dispatch(api.util.upsertQueryData('get', { id: createdEntity.id }, createdEntity));
       }
     },
-    handleEntitySearch: async (request, { shouldUpsertEntityQueries = true, dispatch, queryFulfilled }) => {
+    // TODO: Transform to upsertEntityQueries
+    handleEntitySearch: async (request, { shouldUpsertEntityQueries = false, dispatch, queryFulfilled }) => {
       if (!shouldUpsertEntityQueries) {
         return;
       }

--- a/src/utils/create-infinite-query-hook.ts
+++ b/src/utils/create-infinite-query-hook.ts
@@ -1,0 +1,152 @@
+import { ThunkDispatch, UnknownAction } from '@reduxjs/toolkit';
+import { RefetchConfigOptions, SubscriptionOptions } from '@reduxjs/toolkit/dist/query/core/apiState.d';
+import { omit, range } from 'lodash';
+import { SetStateAction, useCallback, useEffect, useMemo, useState } from 'react';
+import { useDispatch } from 'react-redux';
+import { BaseEntity, PaginationRequest, PaginationResponse } from '../models';
+import { EntityApi, EntityApiCustomHooks, EntityMutationEndpointName } from '../types';
+
+export const createEntityApiHooks = <
+  TEntity extends BaseEntity,
+  TRequest extends PaginationRequest,
+  TPaginationResponse extends PaginationResponse<TEntity> = PaginationResponse<TEntity>,
+>(
+  entityApi: Pick<
+    EntityApi<TEntity, TRequest, any, TPaginationResponse, Array<EntityMutationEndpointName>>,
+    'useSearchInfiniteQuery' | 'endpoints' | 'util'
+  >,
+): EntityApiCustomHooks<TEntity, TRequest, TPaginationResponse> => {
+  return {
+    useSearchInfiniteQuery: createInfiniteQueryHook(entityApi)
+  };
+};
+
+export const createInfiniteQueryHook =
+  <
+    TEntity extends BaseEntity,
+    TRequest extends PaginationRequest,
+    TPaginationResponse extends PaginationResponse<TEntity> = PaginationResponse<TEntity>,
+  >(
+    entityApi: Pick<
+      EntityApi<TEntity, TRequest, any, TPaginationResponse, Array<EntityMutationEndpointName>>,
+      'useSearchInfiniteQuery' | 'endpoints' | 'util'
+    >,
+  ) => (
+    searchRequest: TRequest = {} as TRequest,
+    queryOptions: Partial<SubscriptionOptions & RefetchConfigOptions & { skip?: boolean }> = {},
+    utilities: { checkHasNextPage?: (paginationResponse?: PaginationResponse<TEntity>) => boolean } = {},
+  ): typeof result => {
+    const dispatch: ThunkDispatch<any, any, UnknownAction> = useDispatch();
+    const { data, isFetching, ...restEndpointData } = (
+      (entityApi as any).useSearchInfiniteQueryOriginal as typeof entityApi.useSearchInfiniteQuery
+    )(searchRequest as TRequest, queryOptions);
+    const latestSearchRequest = restEndpointData.originalArgs || searchRequest;
+    const maxFetchedPage = data?.pagination?.currentPage;
+
+    const [isRefetching, setIsRefetching] = useState<boolean>(false);
+    const [isFetchingNextPage, setIsFetchingNextPage] = useState(false);
+    const [isFetchingPreviousPage, setIsFetchingPreviousPage] = useState(false);
+    const { checkHasNextPage } = utilities;
+
+    const { items, pagination, minPage, hasNextPage, hasPreviousPage } = useMemo(() => {
+      const items = data?.data || [];
+      const pagination = data?.pagination as TPaginationResponse['pagination'];
+      const minPage = data?.minPage || data?.pagination.currentPage || 1;
+
+      return {
+        minPage,
+        hasPreviousPage: minPage > 1,
+        hasNextPage: checkHasNextPage?.(data) || pagination?.currentPage < pagination?.lastPage,
+        data,
+        items,
+        pagination
+      };
+    }, [data]);
+
+    const setSearchRequest = useCallback(
+      (newRequest: SetStateAction<TRequest>) => {
+        const request =
+          typeof newRequest === 'function' ? newRequest((latestSearchRequest as TRequest) || {}) : newRequest;
+
+        dispatch(entityApi.endpoints.searchInfinite.initiate(request, { forceRefetch: true }));
+      },
+      [entityApi, latestSearchRequest],
+    );
+
+    const fetchNextPage = useCallback(() => {
+      if (hasNextPage && !isFetching) {
+        setIsFetchingNextPage(true);
+        setSearchRequest((currentRequest) => ({ ...currentRequest, page: (maxFetchedPage || 1) + 1 }));
+      }
+    }, [hasNextPage, isFetching, maxFetchedPage, setSearchRequest]);
+
+    const fetchPreviousPage = useCallback(() => {
+      if (hasPreviousPage && !isFetching) {
+        setIsFetchingPreviousPage(true);
+        setSearchRequest((currentRequest) => ({ ...currentRequest, page: minPage - 1 }));
+      }
+    }, [minPage, isFetching, hasPreviousPage, entityApi, setSearchRequest]);
+
+    const refetchAllPages = useCallback(async () => {
+      setIsRefetching(true);
+
+      for (const pageNumber of range(minPage, pagination.currentPage + 1)) {
+        await dispatch(entityApi.endpoints.searchInfinite.initiate({ ...latestSearchRequest, page: pageNumber }));
+      }
+
+      setIsRefetching(false);
+    }, [minPage, pagination, latestSearchRequest, entityApi]);
+
+    const refetchPage = useCallback(
+      async ({ page, withDataReset }: { page: number; withDataReset?: boolean }) => {
+        if (withDataReset) {
+          dispatch(
+            entityApi.util.updateQueryData('searchInfinite', omit(latestSearchRequest, 'page') as TRequest, (draft) => {
+              draft.data = [];
+              draft.minPage = page;
+              draft.pagination.currentPage = page;
+            }),
+          );
+          setSearchRequest(({ ...rest }) => ({ ...rest, page }));
+        }
+
+        return dispatch(
+          entityApi.endpoints.searchInfinite.initiate({ ...latestSearchRequest, page: 1 }, { forceRefetch: true }),
+        );
+      },
+      [entityApi, latestSearchRequest],
+    );
+
+    const refetch = useCallback(() => {
+      setIsRefetching(true);
+
+      return refetchPage({ page: 1, withDataReset: true });
+    }, [refetchPage]);
+
+    useEffect(() => {
+      if (!isFetching) {
+        setIsRefetching(false);
+        setIsFetchingNextPage(false);
+        setIsFetchingPreviousPage(false);
+      }
+    }, [isFetching]);
+
+    const result = {
+      ...restEndpointData,
+      data: items,
+      pagination,
+      isFetching,
+      isFetchingNextPage,
+      isFetchingPreviousPage,
+      isRefetching,
+      hasNextPage,
+      hasPreviousPage,
+      fetchNextPage,
+      fetchPreviousPage,
+      refetch,
+      refetchPage,
+      refetchAllPages
+    };
+
+    return result;
+  };

--- a/src/utils/create-infinite-query-hook.ts
+++ b/src/utils/create-infinite-query-hook.ts
@@ -79,7 +79,12 @@ export const createInfiniteQueryHook =
 
     const fetchPage = useCallback(
       (pageNumber: number) => {
-        return dispatch(entityApi.endpoints.searchInfinite.initiate({ ...latestSearchRequest, page: pageNumber }));
+        return dispatch(
+          entityApi.endpoints.searchInfinite.initiate(
+            { ...latestSearchRequest, page: pageNumber },
+            { forceRefetch: true },
+          ),
+        );
       },
       [entityApi, latestSearchRequest],
     );

--- a/src/utils/create-infinite-query-hook.ts
+++ b/src/utils/create-infinite-query-hook.ts
@@ -23,7 +23,7 @@ export const createEntityApiHooks = <
   // NOTE: Preserve original hooks to extend them
   Object.keys(entityApiHooks).forEach((key) => {
     const hookName = key as keyof EntityApiCustomHooks;
-    set(entityApi, getPreservedHookName(hookName), entityApiHooks[hookName]);
+    set(entityApi, getPreservedHookName(hookName), entityApi[hookName]);
   });
 
   return entityApiHooks;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -8,3 +8,4 @@ export * from './immutable-merge';
 export * from './is-browser-platform';
 export * from './prepare-request-params';
 export * from './prepare-server-side-request-headers';
+export * from './create-infinite-query-hook';


### PR DESCRIPTION
Key changes:

- the `useInfiniteQuery` and `useSearchQuery` hooks are deprecated;
- instead the `useSearchInfiniteQuery` endpoint for entity apis is extended with functionality from `useInfiniteQuery` hook; 
- `searchRequest` and `setSearchRequest` are removed from the hook from now. This should make the hook easier to use and reduce code complexity, since hook just passing props into RTKQ's `useQuery` hook