### PR TITLE
Updated custom utils for entity api

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,14 @@ Wrapper utilities for CRUD operations with REST APIs entities using [RTK Query](
 npm i @ronas-it/rtkq-entity-api
 ```
 
+If your app uses `axios-observable`, install it along with `rxjs`:
+
+```sh
+npm i axios-observable rxjs
+```
+
+Note that support of `axios-observable` will be removed in upcoming major release.
+
 2. Create base query with your API configuration, for example [using Axios](https://redux-toolkit.js.org/rtk-query/usage/customizing-queries#axios-basequery):
 
 ```ts
@@ -42,9 +50,3 @@ export const usersApi = createEntityApi({
 ```
 
 4. Use the api you created as usual one [created by RTK Query](https://redux-toolkit.js.org/rtk-query/overview#basic-usage)
-
-## TODOs
-
-1. Extend Readme
-1. Add code documentation and examples
-1. Remove peer-dependencies from axios-observable and luxon

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "@reduxjs/toolkit": "^2.2.1",
         "axios": "^1.6.7",
-        "axios-observable": "^2.0.0",
         "class-transformer": "^0.5.1",
         "immer": "^10.0.3",
         "lodash": "^4.17.21",
@@ -26,6 +25,7 @@
         "@types/react": "~18.2.56",
         "@typescript-eslint/eslint-plugin": "7.0.1",
         "@typescript-eslint/parser": "7.0.1",
+        "axios-observable": "^2.0.0",
         "eslint": "8.56.0",
         "eslint-config-prettier": "^9.1.0",
         "eslint-import-resolver-typescript": "^3.6.1",
@@ -35,10 +35,15 @@
         "husky": "^8.0.2",
         "lint-staged": "^14.0.1",
         "prettier": "^3.0.3",
+        "rxjs": "^7.8.1",
         "tsc-files": "^1.1.4",
         "tsup": "^8.0.2",
         "type-fest": "^3.0.0",
         "typescript": "~5.3.3"
+      },
+      "peerDependencies": {
+        "axios-observable": "^2.0.0",
+        "rxjs": "^7.0.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -1432,6 +1437,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/axios-observable/-/axios-observable-2.0.0.tgz",
       "integrity": "sha512-CINOLfMLwAyf2km/nRBybF9OyWXOfRA5ftoYn2Q+Rb2w4KB/FIylk68y7rgI/na6Jen5/I8R9bt6VtDdF/zoyA==",
+      "dev": true,
       "peerDependencies": {
         "axios": "^1.0.0",
         "rxjs": "^7.0.0"
@@ -4530,6 +4536,15 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.0.tgz",
@@ -5119,6 +5134,12 @@
         "minimist": "^1.2.6",
         "strip-bom": "^3.0.0"
       }
+    },
+    "node_modules/tslib": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
+      "dev": true
     },
     "node_modules/tsup": {
       "version": "8.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,18 @@
       "license": "MIT",
       "dependencies": {
         "@reduxjs/toolkit": "^2.2.1",
+        "axios": "^1.6.7",
+        "axios-observable": "^2.0.0",
         "class-transformer": "^0.5.1",
+        "immer": "^10.0.3",
+        "lodash": "^4.17.21",
+        "luxon": "^3.4.4",
+        "react-redux": "^9.1.0",
         "reflect-metadata": "^0.2.1"
       },
       "devDependencies": {
+        "@types/lodash": "^4.14.182",
+        "@types/luxon": "^3.4.2",
         "@types/node": "16.11.7",
         "@types/react": "~18.2.56",
         "@typescript-eslint/eslint-plugin": "7.0.1",
@@ -31,16 +39,6 @@
         "tsup": "^8.0.2",
         "type-fest": "^3.0.0",
         "typescript": "~5.3.3"
-      },
-      "peerDependencies": {
-        "@types/lodash": "^4.14.182",
-        "@types/luxon": "^3.4.2",
-        "axios": "^1.6.7",
-        "axios-observable": "^2.0.0",
-        "immer": "^10.0.3",
-        "lodash": "^4.17.21",
-        "luxon": "^3.4.4",
-        "react-redux": "^9.1.0"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -857,16 +855,16 @@
       "dev": true
     },
     "node_modules/@types/lodash": {
-      "version": "4.14.202",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
-      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ==",
-      "peer": true
+      "version": "4.17.4",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.17.4.tgz",
+      "integrity": "sha512-wYCP26ZLxaT3R39kiN2+HcJ4kTd3U1waI/cY7ivWYqFP6pW3ZNpvi6Wd6PHZx7T/t8z0vlkXMg3QYLa7DZ/IJQ==",
+      "dev": true
     },
     "node_modules/@types/luxon": {
       "version": "3.4.2",
       "resolved": "https://registry.npmjs.org/@types/luxon/-/luxon-3.4.2.tgz",
       "integrity": "sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==",
-      "peer": true
+      "dev": true
     },
     "node_modules/@types/node": {
       "version": "16.11.7",
@@ -878,13 +876,13 @@
       "version": "15.7.11",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.11.tgz",
       "integrity": "sha512-ga8y9v9uyeiLdpKddhxYQkxNDrfvuPrlFb0N1qnZZByvcElJaXthF1UhvCh9TLWJBEHeNtdnbysW7Y6Uq8CVng==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/react": {
       "version": "18.2.56",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.56.tgz",
       "integrity": "sha512-NpwHDMkS/EFZF2dONFQHgkPRwhvgq/OAvIaGQzxGSBmaeR++kTg6njr15Vatz0/2VcCEwJQFi6Jf4Q0qBu0rLA==",
-      "devOptional": true,
+      "dev": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -895,7 +893,7 @@
       "version": "0.16.8",
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.8.tgz",
       "integrity": "sha512-WZLiwShhwLRmeV6zH+GkbOFT6Z6VklCItrDioxUnv+u4Ll+8vKeFySoFyK/0ctcRpOmwAicELfmys1sDc/Rw+A==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/@types/semver": {
       "version": "7.5.7",
@@ -906,8 +904,7 @@
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.3.tgz",
-      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA==",
-      "peer": true
+      "integrity": "sha512-EwmlvuaxPNej9+T4v5AuBPJa2x2UOJVdjCtDHgcDqitUeOtjnJKJ+apYjVcAoBEMjKW1VVFGZLUb5+qqa09XFA=="
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "7.0.1",
@@ -1407,8 +1404,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
-      "peer": true
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.6",
@@ -1426,7 +1422,6 @@
       "version": "1.6.7",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.6.7.tgz",
       "integrity": "sha512-/hDJGff6/c7u0hDkvkGxR/oy6CbCs8ziCsC7SqmhjfozqiJGc8Z11wrv9z9lYfY4K8l+H9TpjcMDX0xOZmx+RA==",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.4",
         "form-data": "^4.0.0",
@@ -1437,7 +1432,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/axios-observable/-/axios-observable-2.0.0.tgz",
       "integrity": "sha512-CINOLfMLwAyf2km/nRBybF9OyWXOfRA5ftoYn2Q+Rb2w4KB/FIylk68y7rgI/na6Jen5/I8R9bt6VtDdF/zoyA==",
-      "peer": true,
       "peerDependencies": {
         "axios": "^1.0.0",
         "rxjs": "^7.0.0"
@@ -1648,7 +1642,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "peer": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -1689,7 +1682,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "devOptional": true
+      "dev": true
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -1752,7 +1745,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
-      "peer": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -2542,7 +2534,6 @@
           "url": "https://github.com/sponsors/RubenVerborgh"
         }
       ],
-      "peer": true,
       "engines": {
         "node": ">=4.0"
       },
@@ -2593,7 +2584,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
       "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "peer": true,
       "dependencies": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -3422,7 +3412,8 @@
     "node_modules/js-tokens": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
     },
     "node_modules/js-yaml": {
       "version": "4.1.0",
@@ -3609,8 +3600,7 @@
     "node_modules/lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "peer": true
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",
@@ -3674,6 +3664,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "dev": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -3697,7 +3688,6 @@
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.4.4.tgz",
       "integrity": "sha512-zobTr7akeGHnv7eBOXcRgMeCP6+uyYsczwmeRCauvpvaAltgNyTbLH/+VaEAPUeWBT+1GuNmz4wC/6jtQzbbVA==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -3734,7 +3724,6 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
-      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -3743,7 +3732,6 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
-      "peer": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -4248,8 +4236,7 @@
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
-      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
-      "peer": true
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.3.1",
@@ -4280,18 +4267,6 @@
         }
       ]
     },
-    "node_modules/react": {
-      "version": "18.2.0",
-      "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
-      "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -4299,10 +4274,9 @@
       "dev": true
     },
     "node_modules/react-redux": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.0.tgz",
-      "integrity": "sha512-6qoDzIO+gbrza8h3hjMA9aq4nwVFCKFtY2iLxCtVT38Swyy2C/dJCGBXHeHLtx6qlg/8qzc2MrhOeduf5K32wQ==",
-      "peer": true,
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-9.1.2.tgz",
+      "integrity": "sha512-0OA4dhM1W48l3uzmv6B7TXPCGmokUU4p1M44DGN2/D9a1FjVPukVjER1PcPX97jIg6aUeLq1XJo1IpfbgULn0w==",
       "dependencies": {
         "@types/use-sync-external-store": "^0.0.3",
         "use-sync-external-store": "^1.0.0"
@@ -4310,14 +4284,10 @@
       "peerDependencies": {
         "@types/react": "^18.2.25",
         "react": "^18.0",
-        "react-native": ">=0.69",
         "redux": "^5.0.0"
       },
       "peerDependenciesMeta": {
         "@types/react": {
-          "optional": true
-        },
-        "react-native": {
           "optional": true
         },
         "redux": {
@@ -4559,21 +4529,6 @@
       "dependencies": {
         "queue-microtask": "^1.2.2"
       }
-    },
-    "node_modules/rxjs": {
-      "version": "7.8.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
-      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
-      "peer": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
-    "node_modules/rxjs/node_modules/tslib": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
-      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==",
-      "peer": true
     },
     "node_modules/safe-array-concat": {
       "version": "1.1.0",
@@ -5440,10 +5395,9 @@
       }
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.0.tgz",
-      "integrity": "sha512-eEgnFxGQ1Ife9bzYs6VLi8/4X6CObHMw9Qr9tPY43iKwsPw8xE8+EFsf/2cFZ5S3esXgpWgtSCtLNS41F+sKPA==",
-      "peer": true,
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -38,13 +38,17 @@
   "dependencies": {
     "@reduxjs/toolkit": "^2.2.1",
     "axios": "^1.6.7",
-    "axios-observable": "^2.0.0",
     "class-transformer": "^0.5.1",
     "immer": "^10.0.3",
     "lodash": "^4.17.21",
     "luxon": "^3.4.4",
     "react-redux": "^9.1.0",
-    "reflect-metadata": "^0.2.1"
+    "reflect-metadata": "^0.2.1",
+    "axios-observable": "^2.0.0"
+  },
+  "peerDependencies": {
+    "axios-observable": "^2.0.0",
+    "rxjs": "^7.0.0"
   },
   "devDependencies": {
     "@types/lodash": "^4.14.182",
@@ -53,6 +57,7 @@
     "@types/react": "~18.2.56",
     "@typescript-eslint/eslint-plugin": "7.0.1",
     "@typescript-eslint/parser": "7.0.1",
+    "axios-observable": "^2.0.0",
     "eslint": "8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-import-resolver-typescript": "^3.6.1",
@@ -62,6 +67,7 @@
     "husky": "^8.0.2",
     "lint-staged": "^14.0.1",
     "prettier": "^3.0.3",
+    "rxjs": "^7.8.1",
     "tsc-files": "^1.1.4",
     "tsup": "^8.0.2",
     "type-fest": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -37,20 +37,18 @@
   },
   "dependencies": {
     "@reduxjs/toolkit": "^2.2.1",
-    "class-transformer": "^0.5.1",
-    "reflect-metadata": "^0.2.1"
-  },
-  "peerDependencies": {
-    "@types/lodash": "^4.14.182",
-    "@types/luxon": "^3.4.2",
     "axios": "^1.6.7",
     "axios-observable": "^2.0.0",
+    "class-transformer": "^0.5.1",
     "immer": "^10.0.3",
     "lodash": "^4.17.21",
     "luxon": "^3.4.4",
-    "react-redux": "^9.1.0"
+    "react-redux": "^9.1.0",
+    "reflect-metadata": "^0.2.1"
   },
   "devDependencies": {
+    "@types/lodash": "^4.14.182",
+    "@types/luxon": "^3.4.2",
     "@types/node": "16.11.7",
     "@types/react": "~18.2.56",
     "@typescript-eslint/eslint-plugin": "7.0.1",

--- a/src/create-entity-api.ts
+++ b/src/create-entity-api.ts
@@ -127,9 +127,6 @@ export function createEntityApi<
             return prepareRequestParams(omit(queryArgs, ['page']) as TSearchRequest, entitySearchRequestConstructor);
           },
           forceRefetch: ({ currentArg, previousArg }) => currentArg?.page !== previousArg?.page,
-          async onQueryStarted(...args) {
-            await entityApiUtils.handleEntitySearch(...args);
-          },
           transformResponse: (response, _, request) => {
             const { data, pagination } = plainToInstance(entitySearchResponseConstructor, response);
 
@@ -198,7 +195,7 @@ export function createEntityApi<
             };
           },
           async onQueryStarted(arg, api) {
-            await entityApiUtils.patchEntityQueries(arg, api);
+            await entityApiUtils.handleEntityUpdate(arg, api, { optimistic: false });
           },
           transformResponse: (response: object | undefined, _error, arg) => response
               ? createEntityInstance<TEntity>(entityConstructor, response)
@@ -211,7 +208,7 @@ export function createEntityApi<
             url: `${baseEndpoint}/${id}`
           }),
           async onQueryStarted(arg, api) {
-            await entityApiUtils.clearEntityQueries(arg, api);
+            await entityApiUtils.handleEntityDelete(arg, api, { optimistic: false });
           }
         })
       };

--- a/src/create-entity-api.ts
+++ b/src/create-entity-api.ts
@@ -204,7 +204,7 @@ export function createEntityApi<
             };
           },
           async onQueryStarted(arg, api) {
-            await entityApiUtils.handleEntityUpdate(arg, { ...api, optimistic: false });
+            await entityApiUtils.patchEntityQueries(arg, api);
           },
           transformResponse: (response: object | undefined, _error, arg) => response
               ? createEntityInstance<TEntity>(entityConstructor, response)
@@ -217,7 +217,7 @@ export function createEntityApi<
             url: `${baseEndpoint}/${id}`
           }),
           async onQueryStarted(arg, api) {
-            await entityApiUtils.handleEntityDelete(arg, { ...api, optimistic: false });
+            await entityApiUtils.clearEntityQueries(arg, api);
           }
         })
       };

--- a/src/create-entity-api.ts
+++ b/src/create-entity-api.ts
@@ -87,9 +87,6 @@ export function createEntityApi<
               data: formattedParams
             };
           },
-          async onQueryStarted(...args) {
-            await entityApiUtils.handleEntityCreate(...args);
-          },
           transformResponse: (response: object) => createEntityInstance<TEntity>(entityConstructor, response)
         }),
 
@@ -102,9 +99,6 @@ export function createEntityApi<
             };
           },
           serializeQueryArgs: ({ queryArgs }) => prepareRequestParams(queryArgs, entitySearchRequestConstructor),
-          async onQueryStarted(...args) {
-            await entityApiUtils.handleEntitySearch(...args);
-          },
           transformResponse: (response) => {
             const { data, pagination } = plainToInstance(entitySearchResponseConstructor, response);
 

--- a/src/types/entity-api-utils.ts
+++ b/src/types/entity-api-utils.ts
@@ -47,13 +47,16 @@ export type EntityApiUtils<
   ) => void | Promise<void>;
   handleEntityUpdate: (
     arg: EntityPartial<TEntity> | TEntity['id'],
-    endpointLifecycle: {
+    endpointLifecycle: MutationLifecycleApi<typeof arg, BaseQueryFunction, EntityPartial<TEntity> | void, string>,
+    options?: {
       optimistic?: boolean;
       shouldRefetchEntity?: boolean;
-    } & MutationLifecycleApi<typeof arg, BaseQueryFunction, EntityPartial<TEntity> | void, string>,
+      tags?: ReadonlyArray<TagDescription<string>>;
+    },
   ) => void | Promise<void>;
   handleEntityDelete: (
     arg: TEntity['id'],
-    endpointLifecycle: { optimistic?: boolean } & MutationLifecycleApi<typeof arg, BaseQueryFunction, void, string>,
+    endpointLifecycle: MutationLifecycleApi<typeof arg, BaseQueryFunction, void, string>,
+    options?: { optimistic?: boolean; tags?: ReadonlyArray<TagDescription<string>> },
   ) => void | Promise<void>;
 };

--- a/src/types/entity-api-utils.ts
+++ b/src/types/entity-api-utils.ts
@@ -2,7 +2,8 @@ import { PatchCollection } from '@reduxjs/toolkit/dist/query/core/buildThunks.d'
 import {
   LifecycleApi,
   MutationLifecycleApi,
-  QueryLifecycleApi
+  QueryLifecycleApi,
+  TagDescription
 } from '@reduxjs/toolkit/dist/query/endpointDefinitions.d';
 import { BaseEntity, EntityRequest, PaginationRequest, PaginationResponse } from '../models';
 import { BaseQueryFunction } from '../utils/create-axios-base-query';
@@ -16,21 +17,28 @@ export type EntityApiUtils<
   patchEntityQueries: (
     entityData: EntityPartial<TEntity>,
     endpointLifecycle: Pick<LifecycleApi, 'dispatch' | 'getState'>,
-    shouldRefetchEntity?: boolean,
+    options?: { shouldRefetchEntity?: boolean; tags?: ReadonlyArray<TagDescription<string>> },
   ) => Promise<Array<PatchCollection>>;
   fetchEntity: (
     id: TEntity['id'],
     params: TSearchRequest | TEntityRequest,
-    dispatch: LifecycleApi['dispatch'],
+    endpointLifecycle: Pick<LifecycleApi, 'dispatch'>,
   ) => Promise<TEntity>;
   clearEntityQueries: (
     entityId: TEntity['id'],
     endpointLifecycle: Pick<LifecycleApi, 'dispatch' | 'getState'>,
+    options?: { tags?: ReadonlyArray<TagDescription<string>> },
   ) => Promise<Array<PatchCollection>>;
+  /**
+   * @deprecated This utility will be removed. Please use 'util.upsertQueryData' if you need to prefill entity query.
+   */
   handleEntityCreate: (
     arg: Partial<TEntity>,
     endpointLifecycle: MutationLifecycleApi<typeof arg, BaseQueryFunction, TEntity | void, string>,
   ) => void | Promise<void>;
+  /**
+   * @deprecated This utility will be removed. Please use 'util.upsertQueryData' if you need to prefill entity query.
+   */
   handleEntitySearch: (
     arg: TSearchRequest,
     endpointLifecycle: {

--- a/src/utils/create-axios-base-query.ts
+++ b/src/utils/create-axios-base-query.ts
@@ -2,6 +2,7 @@ import { SerializedError } from '@reduxjs/toolkit';
 import { BaseQueryApi, BaseQueryFn } from '@reduxjs/toolkit/dist/query/index.d';
 import { MaybePromise } from '@reduxjs/toolkit/dist/query/tsHelpers.d';
 import { AxiosError, AxiosInstance, AxiosRequestConfig, AxiosResponse, RawAxiosRequestHeaders } from 'axios';
+// TODO: Drop support for axios-observable in next major version
 import { Axios as AxiosObservable } from 'axios-observable';
 import { merge } from 'lodash';
 import { lastValueFrom } from 'rxjs';
@@ -29,10 +30,17 @@ export const createAxiosBaseQuery = ({ getHttpClient, prepareHeaders }: AxiosBas
     const httpClient = getHttpClient(api as BaseQueryApi & { extra?: any });
 
     try {
-      const response =
-        httpClient instanceof AxiosObservable
-          ? await lastValueFrom(httpClient.request(requestConfig))
-          : await httpClient.request(requestConfig);
+      const usesAxiosObservable = httpClient instanceof AxiosObservable;
+
+      if (usesAxiosObservable) {
+        console.warn(
+          'Support of Axios Observable is deprecated and will be removed in the next major version. Please use Axios instead',
+        );
+      }
+
+      const response = usesAxiosObservable
+        ? await lastValueFrom(httpClient.request(requestConfig))
+        : await httpClient.request(requestConfig);
 
       return {
         data: response.data,

--- a/src/utils/create-axios-base-query.ts
+++ b/src/utils/create-axios-base-query.ts
@@ -21,6 +21,8 @@ export type AxiosBaseQueryArgs = {
 };
 
 export const createAxiosBaseQuery = ({ getHttpClient, prepareHeaders }: AxiosBaseQueryArgs): BaseQueryFunction => {
+  let isDeprecationWarningShown = false;
+
   return async (requestConfig, api: BaseQueryApi) => {
     const extraHeaders: RawAxiosRequestHeaders = prepareHeaders
       ? await prepareHeaders(api as BaseQueryApi & { extra?: any })
@@ -32,9 +34,10 @@ export const createAxiosBaseQuery = ({ getHttpClient, prepareHeaders }: AxiosBas
     try {
       const usesAxiosObservable = httpClient instanceof AxiosObservable;
 
-      if (usesAxiosObservable) {
+      if (!isDeprecationWarningShown && usesAxiosObservable) {
+        isDeprecationWarningShown = true;
         console.warn(
-          'Support of Axios Observable is deprecated and will be removed in the next major version. Please use Axios instead',
+          'Support of Axios Observable is deprecated and will be removed in the next major version. Please use Axios instead.',
         );
       }
 

--- a/src/utils/create-entity-api-utils.ts
+++ b/src/utils/create-entity-api-utils.ts
@@ -33,7 +33,7 @@ export const createEntityApiUtils = <
   const entityName = api.reducerPath;
 
   const entityApiUtils: EntityApiUtils<TEntity, TSearchRequest, TEntityRequest> = {
-    fetchEntity: async (id, params, dispatch) => {
+    fetchEntity: async (id, params, { dispatch }) => {
       const entityRequest = createEntityInstance<TEntityRequest>(
         entityGetRequestConstructor as ClassConstructor<TEntityRequest>,
         params,
@@ -44,22 +44,26 @@ export const createEntityApiUtils = <
 
       return await dispatch(api.endpoints.get.initiate({ id, params: entityRequest }, { forceRefetch: true })).unwrap();
     },
-    patchEntityQueries: async (entityData, { dispatch, getState }, shouldRefetchEntity) => {
+    patchEntityQueries: async (entityData, { dispatch, getState }, options = {}) => {
+      const { shouldRefetchEntity, tags } = options;
       const patchResults: Array<PatchCollection> = [];
 
       if (!entityData?.id) {
         return patchResults;
       }
 
-      const cachedQueries = api.util.selectInvalidatedBy(getState(), [
-        { type: entityName, id: entityData.id },
-        // TODO: Remove selecting all lists once issue is fixed: https://github.com/reduxjs/redux-toolkit/issues/3583
-        { type: entityName, id: EntityTagID.LIST }
-      ]);
+      const cachedQueries = api.util.selectInvalidatedBy(
+        getState(),
+        tags || [
+          { type: entityName, id: entityData.id },
+          // TODO: Remove selecting all lists once issue is fixed: https://github.com/reduxjs/redux-toolkit/issues/3583
+          { type: entityName, id: EntityTagID.LIST }
+        ],
+      );
 
       for (const { endpointName, originalArgs } of cachedQueries) {
         const existingEntity = shouldRefetchEntity
-          ? await entityApiUtils.fetchEntity(entityData.id, originalArgs?.params || originalArgs, dispatch)
+          ? await entityApiUtils.fetchEntity(entityData.id, originalArgs?.params || originalArgs, { dispatch })
           : entityData;
 
         const action = api.util.updateQueryData(
@@ -84,18 +88,21 @@ export const createEntityApiUtils = <
 
       return patchResults;
     },
-    clearEntityQueries: async (id, { dispatch, getState }) => {
+    clearEntityQueries: async (id, { dispatch, getState }, { tags } = {}) => {
       const patchResults: Array<PatchCollection> = [];
 
       if (!id) {
         return patchResults;
       }
 
-      const cachedQueries = api.util.selectInvalidatedBy(getState(), [
-        { type: entityName, id },
-        // TODO: Remove selecting all lists once issue is fixed: https://github.com/reduxjs/redux-toolkit/issues/3583
-        { type: entityName, id: EntityTagID.LIST }
-      ]);
+      const cachedQueries = api.util.selectInvalidatedBy(
+        getState(),
+        tags || [
+          { type: entityName, id },
+          // TODO: Remove selecting all lists once issue is fixed: https://github.com/reduxjs/redux-toolkit/issues/3583
+          { type: entityName, id: EntityTagID.LIST }
+        ],
+      );
 
       for (const { endpointName, originalArgs } of cachedQueries) {
         const action = api.util.updateQueryData(
@@ -107,6 +114,7 @@ export const createEntityApiUtils = <
 
               if (existingItemIndex > -1) {
                 endpointData.data.splice(existingItemIndex, 1);
+                endpointData.pagination.total--;
               }
             }
           },
@@ -118,6 +126,9 @@ export const createEntityApiUtils = <
 
       return patchResults;
     },
+    /**
+     * @deprecated This utility will be removed. Please use 'util.upsertQueryData' if you need to prefill entity query.
+     */
     handleEntityCreate: async (_args, { dispatch, queryFulfilled }) => {
       const { data: createdEntity } = await queryFulfilled;
 
@@ -125,7 +136,9 @@ export const createEntityApiUtils = <
         await dispatch(api.util.upsertQueryData('get', { id: createdEntity.id }, createdEntity));
       }
     },
-    // TODO: Transform to upsertEntityQueries
+    /**
+     * @deprecated This utility will be removed. Please use 'util.upsertQueryData' if you need to prefill entity query.
+     */
     handleEntitySearch: async (request, { shouldUpsertEntityQueries = false, dispatch, queryFulfilled }) => {
       if (!shouldUpsertEntityQueries) {
         return;
@@ -143,11 +156,16 @@ export const createEntityApiUtils = <
         dispatch(api.util.upsertQueryData('get', { id: entity.id, params: entityRequest }, entity));
       }
     },
-    handleEntityUpdate: async (arg, { optimistic, shouldRefetchEntity, dispatch, queryFulfilled, getState }) => {
+    handleEntityUpdate: async (arg, { dispatch, queryFulfilled, getState }, options) => {
+      const { optimistic, shouldRefetchEntity, tags } = options || {};
       const itemPatch = typeof arg === 'object' && arg.id ? arg : ({ id: arg } as EntityPartial<TEntity>);
 
       if (optimistic) {
-        const patches = await entityApiUtils.patchEntityQueries(itemPatch, { dispatch, getState }, shouldRefetchEntity);
+        const patches = await entityApiUtils.patchEntityQueries(
+          itemPatch,
+          { dispatch, getState },
+          { shouldRefetchEntity, tags },
+        );
 
         queryFulfilled.catch(() => {
           patches.forEach((patch) => {
@@ -160,13 +178,15 @@ export const createEntityApiUtils = <
         await entityApiUtils.patchEntityQueries(
           updatedEntityData || itemPatch,
           { dispatch, getState },
-          shouldRefetchEntity,
+          { shouldRefetchEntity, tags },
         );
       }
     },
-    handleEntityDelete: async (id, { optimistic, dispatch, queryFulfilled, getState }) => {
+    handleEntityDelete: async (id, { dispatch, queryFulfilled, getState }, options) => {
+      const { optimistic, tags } = options || {};
+
       if (optimistic) {
-        const patches = await entityApiUtils.clearEntityQueries(id, { dispatch, getState });
+        const patches = await entityApiUtils.clearEntityQueries(id, { dispatch, getState }, { tags });
 
         queryFulfilled.catch(() => {
           patches.forEach((patch) => {
@@ -176,7 +196,7 @@ export const createEntityApiUtils = <
       } else {
         await queryFulfilled;
 
-        await entityApiUtils.clearEntityQueries(id, { dispatch, getState });
+        await entityApiUtils.clearEntityQueries(id, { dispatch, getState }, { tags });
       }
     }
   };


### PR DESCRIPTION
Key changes:
- deprecate `handleEntityCreate` and `handleEntitySearch` utils as redundant;
- make arguments of other utils consistent;
- add ability to pass custom tags to entity api utils;
- fix package dependencies list;
- deprecate use of `axios-observable`