### PR TITLE
fix: temporary lock redux toolkit version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.3.1",
       "license": "MIT",
       "dependencies": {
-        "@reduxjs/toolkit": "^2.2.1",
+        "@reduxjs/toolkit": "2.2.6",
         "axios": "^1.6.7",
         "axios-observable": "^2.0.0",
         "class-transformer": "^0.5.1",
@@ -651,14 +651,15 @@
       }
     },
     "node_modules/@reduxjs/toolkit": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.2.1.tgz",
-      "integrity": "sha512-8CREoqJovQW/5I4yvvijm/emUiCCmcs4Ev4XPWd4mizSO+dD3g5G6w34QK5AGeNrSH7qM8Fl66j4vuV7dpOdkw==",
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/@reduxjs/toolkit/-/toolkit-2.2.6.tgz",
+      "integrity": "sha512-kH0r495c5z1t0g796eDQAkYbEQ3a1OLYN9o8jQQVZyKyw367pfRGS+qZLkHYvFHiUUdafpoSlQ2QYObIApjPWA==",
+      "license": "MIT",
       "dependencies": {
         "immer": "^10.0.3",
         "redux": "^5.0.1",
         "redux-thunk": "^3.1.0",
-        "reselect": "^5.0.1"
+        "reselect": "^5.1.0"
       },
       "peerDependencies": {
         "react": "^16.9.0 || ^17.0.0 || ^18",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "prepare": "husky install"
   },
   "dependencies": {
-    "@reduxjs/toolkit": "^2.2.1",
+    "@reduxjs/toolkit": "2.2.6",
     "axios": "^1.6.7",
     "class-transformer": "^0.5.1",
     "immer": "^10.0.3",


### PR DESCRIPTION
Temporary locked redux-tookit version because of removed types in v2.2.6.
Issue: `https://github.com/reduxjs/redux-toolkit/issues/4554`