### PR TITLE
Fix refetching for infinite query hook

### DIFF
--- a/src/create-entity-api.ts
+++ b/src/create-entity-api.ts
@@ -214,10 +214,7 @@ export function createEntityApi<
           },
           providesTags: (response) => getEntityTags(entityName, response, getEntityId),
           merge: (cache, response) => {
-            if (
-              response.pagination.currentPage === 1 &&
-              cache.pagination.currentPage === response.pagination.currentPage
-            ) {
+            if (response.pagination.currentPage === 1) {
               cache.data = response.data;
               cache.pagination = response.pagination;
             } else {

--- a/src/utils/create-infinite-query-hook.ts
+++ b/src/utils/create-infinite-query-hook.ts
@@ -152,6 +152,7 @@ export const createInfiniteQueryHook =
       refetch,
       refetchLastPage,
       refetchAllPages,
+      fetchPage,
     };
 
     return result;


### PR DESCRIPTION
Infinite queries now can be correctly refetched starting from `page: 1`